### PR TITLE
Add bottom menu and management panels

### DIFF
--- a/src/app/components/Panels.tsx
+++ b/src/app/components/Panels.tsx
@@ -1,0 +1,142 @@
+'use client';
+import React from 'react';
+
+export interface Settings {
+  movement: 'slow' | 'normal' | 'fast';
+  language: string;
+  showLabels: boolean;
+  animateDialogue: boolean;
+}
+
+export interface SaveData {
+  mapId: string;
+  player: { x: number; y: number };
+  items: string[];
+  updatedAt: string;
+}
+
+interface BaseProps {
+  onClose: () => void;
+  children: React.ReactNode;
+  title: string;
+}
+
+function Panel({ onClose, children, title }: BaseProps) {
+  return (
+    <div className="panel-overlay">
+      <div className="panel">
+        <h2>{title}</h2>
+        {children}
+        <button onClick={onClose}>Close</button>
+      </div>
+    </div>
+  );
+}
+
+interface SettingsPanelProps {
+  settings: Settings;
+  setSettings: (s: Settings) => void;
+  onMainMenu: () => void;
+  onClose: () => void;
+  reset: () => void;
+}
+export function SettingsPanel({ settings, setSettings, onMainMenu, onClose, reset }: SettingsPanelProps) {
+  const handleChange = (key: keyof Settings, value: Settings[keyof Settings]) => {
+    setSettings({ ...settings, [key]: value });
+  };
+  return (
+    <Panel onClose={onClose} title="Settings">
+      <button onClick={onMainMenu}>Back to main menu</button>
+      <label>
+        Movement speed:
+        <select value={settings.movement} onChange={(e) => handleChange('movement', e.target.value as Settings['movement'])}>
+          <option value="slow">Slow</option>
+          <option value="normal">Normal</option>
+          <option value="fast">Fast</option>
+        </select>
+      </label>
+      <label>
+        Language:
+        <select value={settings.language} onChange={(e) => handleChange('language', e.target.value)}>
+          <option value="en">English</option>
+          <option value="nl">Dutch</option>
+          <option value="jp">Japanese</option>
+          <option value="ru">Russian</option>
+          <option value="ar">Arabic</option>
+        </select>
+      </label>
+      <label>
+        <input type="checkbox" checked={settings.showLabels} onChange={(e) => handleChange('showLabels', e.target.checked)} />
+        Show tile labels
+      </label>
+      <label>
+        <input type="checkbox" checked={settings.animateDialogue} onChange={(e) => handleChange('animateDialogue', e.target.checked)} />
+        Dialogue animation
+      </label>
+      <button onClick={reset}>Reset all settings</button>
+    </Panel>
+  );
+}
+
+interface ItemsPanelProps {
+  items: string[];
+  onClose: () => void;
+}
+export function ItemsPanel({ items, onClose }: ItemsPanelProps) {
+  return (
+    <Panel onClose={onClose} title="Items">
+      {items.length === 0 ? <p>No items</p> : (
+        <ul>{items.map((it) => <li key={it}>{it}</li>)}</ul>
+      )}
+    </Panel>
+  );
+}
+
+interface SavePanelProps {
+  saves: (SaveData | null)[];
+  onSave: (slot: number) => void;
+  onClose: () => void;
+}
+export function SavePanel({ saves, onSave, onClose }: SavePanelProps) {
+  return (
+    <Panel onClose={onClose} title="Save Game">
+      {[1,2,3].map((slot) => {
+        const data = saves[slot-1];
+        return (
+          <div key={slot}>
+            <p>Slot {slot}: {data ? new Date(data.updatedAt).toLocaleString() : 'Empty'}</p>
+            <button onClick={() => onSave(slot)}>Save to Slot {slot}</button>
+          </div>
+        );
+      })}
+    </Panel>
+  );
+}
+
+interface LoadPanelProps {
+  saves: (SaveData | null)[];
+  onLoad: (slot: number) => void;
+  onDelete: (slot: number) => void;
+  onClose: () => void;
+}
+export function LoadPanel({ saves, onLoad, onDelete, onClose }: LoadPanelProps) {
+  return (
+    <Panel onClose={onClose} title="Load Game">
+      {[1,2,3].map((slot) => {
+        const data = saves[slot-1];
+        return (
+          <div key={slot}>
+            <p>Slot {slot}: {data ? new Date(data.updatedAt).toLocaleString() : 'Empty'}</p>
+            {data ? (
+              <>
+                <button onClick={() => onLoad(slot)}>Load Slot {slot}</button>
+                <button onClick={() => onDelete(slot)}>Delete Slot {slot}</button>
+              </>
+            ) : null}
+          </div>
+        );
+      })}
+    </Panel>
+  );
+}
+

--- a/src/style/globals.css
+++ b/src/style/globals.css
@@ -201,3 +201,54 @@ h1.title {
     transform: scale(1);
   }
 }
+
+/* Bottom menu */
+.bottom-menu {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(20, 20, 20, 0.9);
+  border-top: 1px solid #444;
+  display: flex;
+  justify-content: space-around;
+  padding: 0.5rem 0;
+  z-index: 100;
+}
+.bottom-menu button {
+  background: #222;
+  border: 1px solid #444;
+  color: white;
+  padding: 0.4rem 0.8rem;
+  border-radius: 4px;
+}
+
+.panel-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.panel {
+  background: #1e1e1e;
+  padding: 1rem;
+  border: 1px solid #555;
+  border-radius: 8px;
+  max-width: 90vw;
+}
+
+.tile-label {
+  position: absolute;
+  bottom: 2px;
+  left: 2px;
+  font-size: 0.5rem;
+  color: #fff;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- add Panels components for settings, items, saving and loading
- create fixed bottom menu bar for toggling panels
- persist settings to localStorage/Supabase
- add typed dialogue option and tile labels
- style new overlay panels and bottom bar

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c34b94c1883318e85a805354733c5