### PR TITLE
Center player in grid

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -412,7 +412,10 @@ export default function Home() {
         )}
         <div
           className="circle player"
-          style={{ top: `${player.y * 10}%`, left: `${player.x * 10}%` }}
+          style={{
+            top: `${(player.y + 0.5) * 10}%`,
+            left: `${(player.x + 0.5) * 10}%`,
+          }}
         />
       </div>
 

--- a/src/style/globals.css
+++ b/src/style/globals.css
@@ -101,11 +101,12 @@ h1.title {
   position: absolute;
   top: 0;
   left: 0;
-  width: 7%;
-  height: 7%;
+  width: 8%;
+  height: 8%;
   display: flex;
   align-items: center;
   justify-content: center;
+  transform: translate(-50%, -50%);
   transition: top 0.25s ease, left 0.25s ease;
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- center player token using CSS transform
- adjust inline style calculation for player coordinates

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c475bf9908331bb2e5efa43c3d8e2