### PR TITLE
Add multilingual system with Dutch support

### DIFF
--- a/src/app/components/Panels.tsx
+++ b/src/app/components/Panels.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React from 'react';
+import { t } from '../../lib/lang';
 
 export interface Settings {
   movement: 'slow' | 'normal' | 'fast';
@@ -19,15 +20,16 @@ interface BaseProps {
   onClose: () => void;
   children: React.ReactNode;
   title: string;
+  lang: string;
 }
 
-function Panel({ onClose, children, title }: BaseProps) {
+function Panel({ onClose, children, title, lang }: BaseProps) {
   return (
     <div className="panel-overlay">
       <div className="panel">
         <h2>{title}</h2>
         {children}
-        <button onClick={onClose}>Close</button>
+        <button onClick={onClose}>{t('close', lang)}</button>
       </div>
     </div>
   );
@@ -45,33 +47,33 @@ export function SettingsPanel({ settings, setSettings, onMainMenu, onClose, rese
     setSettings({ ...settings, [key]: value });
   };
   return (
-    <Panel onClose={onClose} title="Settings">
+    <Panel onClose={onClose} title={t('settings', settings.language)} lang={settings.language}>
       <div className="settings-panel">
-        <button onClick={onMainMenu} aria-label="Back to Main Menu">🔙 Back to Main Menu</button>
+        <button onClick={onMainMenu} aria-label={t('backToMenu', settings.language)}>🔙 {t('backToMenu', settings.language)}</button>
         <label className="setting-group">
-          ⏩ Movement Speed
+          ⏩ {t('movementSpeed', settings.language)}
           <select
-            aria-label="Movement Speed"
+            aria-label={t('movementSpeed', settings.language)}
             value={settings.movement}
             onChange={(e) => handleChange('movement', e.target.value as Settings['movement'])}
           >
-            <option value="slow">Slow</option>
-            <option value="normal">Normal</option>
-            <option value="fast">Fast</option>
+            <option value="slow">{t('slow', settings.language)}</option>
+            <option value="normal">{t('normal', settings.language)}</option>
+            <option value="fast">{t('fast', settings.language)}</option>
           </select>
         </label>
         <label className="setting-group">
-          🌍 Language
+          🌍 {t('language', settings.language)}
           <select
-            aria-label="Language"
+            aria-label={t('language', settings.language)}
             value={settings.language}
             onChange={(e) => handleChange('language', e.target.value)}
           >
-            <option value="en">English</option>
-            <option value="nl">Dutch</option>
-            <option value="jp">Japanese</option>
-            <option value="ru">Russian</option>
-            <option value="ar">Arabic</option>
+            <option value="en">🇬🇧 English</option>
+            <option value="nl">🇳🇱 Nederlands</option>
+            <option value="jp">🇯🇵 Japanese</option>
+            <option value="ru">🇷🇺 Russian</option>
+            <option value="ar">🇸🇦 Arabic</option>
           </select>
         </label>
         <label className="checkbox-label">
@@ -79,20 +81,20 @@ export function SettingsPanel({ settings, setSettings, onMainMenu, onClose, rese
             type="checkbox"
             checked={settings.showLabels}
             onChange={(e) => handleChange('showLabels', e.target.checked)}
-            aria-label="Show Tile Labels"
+            aria-label={t('showTileLabels', settings.language)}
           />
-          🧩 Show Tile Labels
+          🧩 {t('showTileLabels', settings.language)}
         </label>
         <label className="checkbox-label">
           <input
             type="checkbox"
             checked={settings.animateDialogue}
             onChange={(e) => handleChange('animateDialogue', e.target.checked)}
-            aria-label="Dialogue Animation"
+            aria-label={t('dialogueAnimation', settings.language)}
           />
-          💬 Dialogue Animation
+          💬 {t('dialogueAnimation', settings.language)}
         </label>
-        <button onClick={reset} aria-label="Reset All Settings">♻️ Reset All Settings</button>
+        <button onClick={reset} aria-label={t('resetSettings', settings.language)}>♻️ {t('resetSettings', settings.language)}</button>
       </div>
     </Panel>
   );
@@ -101,11 +103,12 @@ export function SettingsPanel({ settings, setSettings, onMainMenu, onClose, rese
 interface ItemsPanelProps {
   items: string[];
   onClose: () => void;
+  lang: string;
 }
-export function ItemsPanel({ items, onClose }: ItemsPanelProps) {
+export function ItemsPanel({ items, onClose, lang }: ItemsPanelProps) {
   return (
-    <Panel onClose={onClose} title="Items">
-      {items.length === 0 ? <p>No items</p> : (
+    <Panel onClose={onClose} title={t('items', lang)} lang={lang}>
+      {items.length === 0 ? <p>{t('noItems', lang)}</p> : (
         <ul>{items.map((it) => <li key={it}>{it}</li>)}</ul>
       )}
     </Panel>
@@ -116,16 +119,17 @@ interface SavePanelProps {
   saves: (SaveData | null)[];
   onSave: (slot: number) => void;
   onClose: () => void;
+  lang: string;
 }
-export function SavePanel({ saves, onSave, onClose }: SavePanelProps) {
+export function SavePanel({ saves, onSave, onClose, lang }: SavePanelProps) {
   return (
-    <Panel onClose={onClose} title="Save Game">
+    <Panel onClose={onClose} title={t('saveGame', lang)} lang={lang}>
       {[1,2,3].map((slot) => {
         const data = saves[slot-1];
         return (
           <div key={slot}>
-            <p>Slot {slot}: {data ? new Date(data.updatedAt).toLocaleString() : 'Empty'}</p>
-            <button onClick={() => onSave(slot)}>Save to Slot {slot}</button>
+            <p>{t('slot', lang)} {slot}: {data ? new Date(data.updatedAt).toLocaleString() : t('empty', lang)}</p>
+            <button onClick={() => onSave(slot)}>{t('saveToSlot', lang)} {slot}</button>
           </div>
         );
       })}
@@ -138,19 +142,20 @@ interface LoadPanelProps {
   onLoad: (slot: number) => void;
   onDelete: (slot: number) => void;
   onClose: () => void;
+  lang: string;
 }
-export function LoadPanel({ saves, onLoad, onDelete, onClose }: LoadPanelProps) {
+export function LoadPanel({ saves, onLoad, onDelete, onClose, lang }: LoadPanelProps) {
   return (
-    <Panel onClose={onClose} title="Load Game">
+    <Panel onClose={onClose} title={t('loadGame', lang)} lang={lang}>
       {[1,2,3].map((slot) => {
         const data = saves[slot-1];
         return (
           <div key={slot}>
-            <p>Slot {slot}: {data ? new Date(data.updatedAt).toLocaleString() : 'Empty'}</p>
+            <p>{t('slot', lang)} {slot}: {data ? new Date(data.updatedAt).toLocaleString() : t('empty', lang)}</p>
             {data ? (
               <>
-                <button onClick={() => onLoad(slot)}>Load Slot {slot}</button>
-                <button onClick={() => onDelete(slot)}>Delete Slot {slot}</button>
+                <button onClick={() => onLoad(slot)}>{t('loadSlot', lang)} {slot}</button>
+                <button onClick={() => onDelete(slot)}>{t('deleteSlot', lang)} {slot}</button>
               </>
             ) : null}
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { findPath } from '../lib/pathfinding';
+import { t } from '../lib/lang';
 import { supabase } from '../lib/supabase';
 import type { User } from '@supabase/supabase-js';
 import type { Tile } from '../lib/types';
@@ -180,7 +181,7 @@ export default function Home() {
     if (error) {
       alert('Login error: ' + error.message);
     } else {
-      alert('Check your email for a magic login link.');
+      alert(t('checkEmail', settings.language));
     }
   };
 
@@ -335,36 +336,36 @@ export default function Home() {
     return (
       <div className="menu-screen">
         <h1 className="title">Praeverse</h1>
-        <button onClick={() => setMenuVisible(false)} aria-label="Start Game">▶ Play</button>
-        <button onClick={() => setShowHelp(true)} aria-label="How to Play">📖 How to Play</button>
+        <button onClick={() => setMenuVisible(false)} aria-label={t('play', settings.language)}>▶ {t('play', settings.language)}</button>
+        <button onClick={() => setShowHelp(true)} aria-label={t('howToPlay', settings.language)}>📖 {t('howToPlay', settings.language)}</button>
 
         {user ? (
           <>
-            <p>Logged in as: {user.email}</p>
-            <button onClick={handleLogout} aria-label="Log Out">🚪 Log Out</button>
+            <p>{t('loggedInAs', settings.language)} {user.email}</p>
+            <button onClick={handleLogout} aria-label={t('logOut', settings.language)}>🚪 {t('logOut', settings.language)}</button>
           </>
         ) : (
           <>
             <input
               type="email"
-              placeholder="Enter email"
+              placeholder={t('loginPrompt', settings.language)}
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               className="menu-input"
             />
-            <button onClick={handleLogin} aria-label="Send Magic Link">🔐 Send Magic Link</button>
+            <button onClick={handleLogin} aria-label={t('sendMagicLink', settings.language)}>🔐 {t('sendMagicLink', settings.language)}</button>
           </>
         )}
 
         {showHelp && (
           <div className="modal">
-            <p><strong>How to Play:</strong></p>
+            <p><strong>{t('howToPlayTitle', settings.language)}</strong></p>
             <ul>
-              <li>Tap a gray tile to move.</li>
-              <li>Double tap a colored circle (NPC) to interact.</li>
-              <li>Dark tiles are walls — they block movement.</li>
+              <li>{t('instructionMove', settings.language)}</li>
+              <li>{t('instructionInteract', settings.language)}</li>
+              <li>{t('instructionWalls', settings.language)}</li>
             </ul>
-            <button onClick={() => setShowHelp(false)} aria-label="Close Help">Close</button>
+            <button onClick={() => setShowHelp(false)} aria-label={t('close', settings.language)}>{t('close', settings.language)}</button>
           </div>
         )}
       </div>
@@ -426,25 +427,25 @@ export default function Home() {
               onClick={() => {
               setDisplayDialogue(null);
             }}
-            aria-label="Close Dialogue"
+            aria-label={t('close', settings.language)}
           >
-            Close
+            {t('close', settings.language)}
           </button>
         </div>
       )}
       </main>
       <div className="bottom-menu">
         <button onClick={() => setActivePanel(activePanel === 'settings' ? null : 'settings')}>
-          Settings
+          {t('settings', settings.language)}
         </button>
         <button onClick={() => setActivePanel(activePanel === 'items' ? null : 'items')}>
-          Items
+          {t('items', settings.language)}
         </button>
         <button onClick={() => setActivePanel(activePanel === 'save' ? null : 'save')}>
-          Save
+          {t('save', settings.language)}
         </button>
         <button onClick={() => setActivePanel(activePanel === 'load' ? null : 'load')}>
-          Load
+          {t('load', settings.language)}
         </button>
       </div>
       {activePanel === 'settings' && (
@@ -460,13 +461,14 @@ export default function Home() {
         />
       )}
       {activePanel === 'items' && (
-        <ItemsPanel items={items} onClose={() => setActivePanel(null)} />
+        <ItemsPanel items={items} onClose={() => setActivePanel(null)} lang={settings.language} />
       )}
       {activePanel === 'save' && (
         <SavePanel
           saves={saves}
           onSave={handleSave}
           onClose={() => setActivePanel(null)}
+          lang={settings.language}
         />
       )}
       {activePanel === 'load' && (
@@ -475,6 +477,7 @@ export default function Home() {
           onLoad={handleLoad}
           onDelete={handleDelete}
           onClose={() => setActivePanel(null)}
+          lang={settings.language}
         />
       )}
     </>

--- a/src/lib/lang.ts
+++ b/src/lib/lang.ts
@@ -1,0 +1,74 @@
+export const translations = {
+  en: {
+    play: 'Play',
+    howToPlay: 'How to Play',
+    sendMagicLink: 'Send Magic Link',
+    backToMenu: 'Back to Main Menu',
+    movementSpeed: 'Movement Speed',
+    language: 'Language',
+    showTileLabels: 'Show Tile Labels',
+    dialogueAnimation: 'Dialogue Animation',
+    resetSettings: 'Reset All Settings',
+    settings: 'Settings',
+    items: 'Items',
+    save: 'Save',
+    load: 'Load',
+    close: 'Close',
+    loginPrompt: 'Enter email',
+    logOut: 'Log Out',
+    loggedInAs: 'Logged in as:',
+    noItems: 'No items',
+    saveGame: 'Save Game',
+    loadGame: 'Load Game',
+    slot: 'Slot',
+    empty: 'Empty',
+    saveToSlot: 'Save to Slot',
+    loadSlot: 'Load Slot',
+    deleteSlot: 'Delete Slot',
+    howToPlayTitle: 'How to Play:',
+    instructionMove: 'Tap a gray tile to move.',
+    instructionInteract: 'Double tap a colored circle (NPC) to interact.',
+    instructionWalls: 'Dark tiles are walls — they block movement.',
+    checkEmail: 'Check your email for a magic login link.'
+  },
+  nl: {
+    play: 'Spelen',
+    howToPlay: 'Hoe te spelen',
+    sendMagicLink: 'Stuur magische link',
+    backToMenu: 'Terug naar menu',
+    movementSpeed: 'Bewegingssnelheid',
+    language: 'Taal',
+    showTileLabels: 'Tegeltekst tonen',
+    dialogueAnimation: 'Dialooganimatie',
+    resetSettings: 'Reset instellingen',
+    settings: 'Instellingen',
+    items: 'Voorwerpen',
+    save: 'Opslaan',
+    load: 'Laden',
+    close: 'Sluiten',
+    loginPrompt: 'Voer e-mail in',
+    logOut: 'Uitloggen',
+    loggedInAs: 'Ingelogd als:',
+    noItems: 'Geen items',
+    saveGame: 'Spel opslaan',
+    loadGame: 'Spel laden',
+    slot: 'Slot',
+    empty: 'Leeg',
+    saveToSlot: 'Opslaan naar slot',
+    loadSlot: 'Laad slot',
+    deleteSlot: 'Verwijder slot',
+    howToPlayTitle: 'Spelregels:',
+    instructionMove: 'Tik op een grijze tegel om te bewegen.',
+    instructionInteract: 'Dubbel tik op een gekleurde cirkel (NPC) om te praten.',
+    instructionWalls: 'Donkere tegels zijn muren — ze blokkeren beweging.',
+    checkEmail: 'Controleer je e-mail voor de magische link.'
+  }
+} as const;
+
+type Language = keyof typeof translations;
+type TranslationKey = keyof typeof translations.en;
+
+export function t(key: TranslationKey, lang?: Language): string {
+  const langStrings = translations[lang ?? 'en'] || translations.en;
+  return langStrings[key] ?? translations.en[key] ?? key;
+}


### PR DESCRIPTION
## Summary
- add translation utility with English and Dutch text
- localize settings panels and buttons
- localize main menu and modal text

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c4d14d56c833194f935462bfce45f